### PR TITLE
feat: 新增 GitHub Actions 自动创建 Release 工作流

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Build and Release with Nuitka
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, windows-latest]
+        include:
+          - os: ubuntu-22.04
+            platform: linux
+            arch: amd64
+          - os: windows-latest
+            platform: windows
+            arch: amd64
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install nuitka
+
+    - name: Build with Nuitka
+      run: |
+        python -m nuitka --standalone --onefile --output-dir=dist --show-progress --assume-yes-for-downloads main.py
+
+    - name: Rename binary on Linux
+      if: matrix.os == 'ubuntu-22.04'
+      shell: bash
+      run: |
+        mkdir bin
+        mv dist/main.bin bin/CC98Autosign-${{ matrix.platform }}-${{ matrix.arch }}
+  
+    - name: Rename binary on Windows
+      if: matrix.os == 'windows-latest'
+      shell: pwsh
+      run: |
+        mkdir bin
+        move dist\main.exe bin\CC98Autosign-${{ matrix.platform }}-${{ matrix.arch }}.exe
+
+    - name: Upload binary artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: CC98Autosign-${{ matrix.platform }}-${{ matrix.arch }}
+        path: bin/*
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: ./artifacts
+
+    - name: Create Release and Upload binaries
+      uses: softprops/action-gh-release@v2
+      with:
+        generate_release_notes: true
+        files: ./artifacts/**/*


### PR DESCRIPTION
# feat: 新增 GitHub Actions 自动创建 Release 工作流

## 变更内容
- 新增 GitHub Actions 工作流，支持在推送 tag后，自动打包并发布 Release。
- 通过 Nuitka 在 Linux 和 Windows 平台分别进行编译，生成独立二进制文件。
- 自动将构建好的二进制文件上传至对应的 GitHub Release 中，便于发布和下载。

## 新增工作流文件
- `.github/workflows/release.yml`

## 工作流主要功能
- 检测以 `v*` 格式推送的标签。
- 在 Ubuntu 22.04 和 Windows 平台分别使用 Nuitka 打包。
- 将编译产物分别上传为 artifact。
- 自动创建 GitHub Release，并附带上传好的二进制文件。

